### PR TITLE
Fix gdnative lib generation script with python3

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -12,7 +12,7 @@ def add_sources(sources, dirpath, extension):
 def gen_gdnative_lib(target, source, env):
     for t in target:
         with open(t.srcnode().path, 'w') as w:
-            w.write(source[0].get_contents().replace('{GDNATIVE_PATH}', os.path.splitext(t.name)[0]).replace('{TARGET}', env['target']))
+            w.write(source[0].get_contents().decode('utf-8').replace('{GDNATIVE_PATH}', os.path.splitext(t.name)[0]).replace('{TARGET}', env['target']))
 
 
 env = Environment()


### PR DESCRIPTION
Building with python3 was generating this error:
```
  File "C:\webrtc-native\SConstruct", line 15, in gen_gdnative_lib
    w.write(source[0].get_contents().replace('{GDNATIVE_PATH}', os.path.splitext(t.name)[0]).replace('{TARGET}', env['target']))
TypeError: a bytes-like object is required, not 'str'
```