### PR TITLE
Change 'credential' to 'credentials' (add 's') to match Javascript version

### DIFF
--- a/src/WebRTCLibPeerConnection.cpp
+++ b/src/WebRTCLibPeerConnection.cpp
@@ -32,7 +32,7 @@ godot_error _parse_ice_server(webrtc::PeerConnectionInterface::RTCConfiguration 
 	if (p_server.has("username") && (v = p_server["username"]) && v.get_type() == godot::Variant::STRING) {
 		ice_server.username = (v.operator godot::String()).utf8().get_data();
 	}
-	if (p_server.has("credential") && (v = p_server["credential"]) && v.get_type() == godot::Variant::STRING) {
+	if (p_server.has("credentials") && (v = p_server["credentials"]) && v.get_type() == godot::Variant::STRING) {
 		ice_server.password = (v.operator godot::String()).utf8().get_data();
 	}
 


### PR DESCRIPTION
I was experimenting with using a TURN server, and discovered that the HTML5/Javascript version uses the key 'credentials' (since it's just passing the data to the `RTCPeerConnection` from the browser), where as the GDNative version is using 'credential' (missing the 's' at the end).

This PR switches it to 'credentials' to match!