### PR TITLE
Bump webrtc to branch-heads/4472. Fixes signalling.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -115,7 +115,7 @@ if target_platform == 'linux':
     else:
         env.Prepend(CCFLAGS=['-O3'])
 
-    env.Append(CCFLAGS=['-fPIC', '-std=c++11'])
+    env.Append(CCFLAGS=['-fPIC', '-std=c++14'])
 
     if target_arch == '32':
         env.Append(CCFLAGS = [ '-m32' ])
@@ -276,7 +276,7 @@ if target == 'debug':
 else:
     lib_path += '/Release'
 
-env.Append(CPPPATH=[webrtc_dir + "/include"])
+env.Append(CPPPATH=[webrtc_dir + "/include", webrtc_dir + "/include/third_party/abseil-cpp"])
 
 if target_platform == "linux":
     env.Append(LIBS=[lib_name, "atomic"])

--- a/src/WebRTCLibDataChannel.hpp
+++ b/src/WebRTCLibDataChannel.hpp
@@ -3,8 +3,8 @@
 
 #include <Godot.hpp> // Godot.hpp must go first, or windows builds breaks
 
-#include "api/peerconnectioninterface.h" // interface for all things needed from WebRTC
-#include "media/base/mediaengine.h" // needed for CreateModularPeerConnectionFactory
+#include "api/peer_connection_interface.h" // interface for all things needed from WebRTC
+#include "media/base/media_engine.h" // needed for CreateModularPeerConnectionFactory
 
 #include "net/WebRTCDataChannelNative.hpp"
 #include "PoolArrays.hpp"

--- a/src/WebRTCLibObservers.cpp
+++ b/src/WebRTCLibObservers.cpp
@@ -15,7 +15,7 @@ void WebRTCLibPeerConnection::GodotCSDO::OnSuccess(webrtc::SessionDescriptionInt
 	parent->queue_signal("session_description_created", 2, desc->type().c_str(), sdp.c_str());
 };
 
-void WebRTCLibPeerConnection::GodotCSDO::OnFailure(const std::string &error){};
+void WebRTCLibPeerConnection::GodotCSDO::OnFailure(webrtc::RTCError error){};
 
 // SetSessionObseerver
 WebRTCLibPeerConnection::GodotSSDO::GodotSSDO(WebRTCLibPeerConnection *parent) {
@@ -23,7 +23,7 @@ WebRTCLibPeerConnection::GodotSSDO::GodotSSDO(WebRTCLibPeerConnection *parent) {
 }
 
 void WebRTCLibPeerConnection::GodotSSDO::OnSuccess(){};
-void WebRTCLibPeerConnection::GodotSSDO::OnFailure(const std::string &error){};
+void WebRTCLibPeerConnection::GodotSSDO::OnFailure(webrtc::RTCError error){};
 
 // PeerConnectionObserver
 WebRTCLibPeerConnection::GodotPCO::GodotPCO(WebRTCLibPeerConnection *parent) {

--- a/src/WebRTCLibPeerConnection.cpp
+++ b/src/WebRTCLibPeerConnection.cpp
@@ -5,6 +5,21 @@
 
 using namespace godot_webrtc;
 
+std::unique_ptr<rtc::Thread> WebRTCLibPeerConnection::signaling_thread = nullptr;
+
+void WebRTCLibPeerConnection::initialize_signaling() {
+	if (signaling_thread.get() == nullptr) {
+		signaling_thread = rtc::Thread::Create();
+	}
+	signaling_thread->Start();
+}
+
+void WebRTCLibPeerConnection::deinitialize_signaling() {
+	if (signaling_thread.get() != nullptr) {
+		signaling_thread->Stop();
+	}
+}
+
 godot_error _parse_ice_server(webrtc::PeerConnectionInterface::RTCConfiguration &r_config, godot::Dictionary p_server) {
 	godot::Variant v;
 	webrtc::PeerConnectionInterface::IceServer ice_server;
@@ -193,8 +208,7 @@ void WebRTCLibPeerConnection::_init() {
 	// create a PeerConnectionFactoryInterface:
 	webrtc::PeerConnectionFactoryDependencies deps;
 
-	signaling_thread = rtc::Thread::Create();
-	ERR_FAIL_COND(!signaling_thread->Start());
+	ERR_FAIL_COND(signaling_thread.get() == nullptr);
 	deps.signaling_thread = signaling_thread.get();
 	pc_factory = webrtc::CreateModularPeerConnectionFactory(std::move(deps));
 

--- a/src/WebRTCLibPeerConnection.cpp
+++ b/src/WebRTCLibPeerConnection.cpp
@@ -57,7 +57,7 @@ godot_error _parse_channel_config(webrtc::DataChannelInit &r_config, godot::Dict
 	// ID makes sense only when negotiated is true (and must be set in that case)
 	ERR_FAIL_COND_V(r_config.negotiated ? r_config.id == -1 : r_config.id != -1, GODOT_ERR_INVALID_PARAMETER);
 	// Only one of maxRetransmits and maxRetransmitTime can be set on a channel.
-	ERR_FAIL_COND_V(r_config.maxRetransmits != -1 && r_config.maxRetransmitTime != -1, GODOT_ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(r_config.maxRetransmits && r_config.maxRetransmitTime, GODOT_ERR_INVALID_PARAMETER);
 	return GODOT_OK;
 }
 
@@ -119,7 +119,7 @@ godot_object *WebRTCLibPeerConnection::create_data_channel(const char *p_channel
 
 godot_error WebRTCLibPeerConnection::create_offer() {
 	ERR_FAIL_COND_V(peer_connection.get() == nullptr, GODOT_ERR_UNCONFIGURED);
-	peer_connection->CreateOffer(ptr_csdo, nullptr);
+	peer_connection->CreateOffer(ptr_csdo, webrtc::PeerConnectionInterface::RTCOfferAnswerOptions());
 	return GODOT_OK;
 }
 
@@ -191,16 +191,12 @@ void WebRTCLibPeerConnection::_init() {
 	mutex_signal_queue = new std::mutex;
 
 	// create a PeerConnectionFactoryInterface:
-	signaling_thread = new rtc::Thread;
-	signaling_thread->Start();
-	pc_factory = webrtc::CreateModularPeerConnectionFactory(
-			nullptr, // rtc::Thread* network_thread,
-			nullptr, // rtc::Thread* worker_thread,
-			signaling_thread,
-			nullptr, // std::unique_ptr<cricket::MediaEngineInterface> media_engine,
-			nullptr, // std::unique_ptr<CallFactoryInterface> call_factory,
-			nullptr // std::unique_ptr<RtcEventLogFactoryInterface> event_log_factory
-	);
+	webrtc::PeerConnectionFactoryDependencies deps;
+
+	signaling_thread = rtc::Thread::Create();
+	ERR_FAIL_COND(!signaling_thread->Start());
+	deps.signaling_thread = signaling_thread.get();
+	pc_factory = webrtc::CreateModularPeerConnectionFactory(std::move(deps));
 
 	// Create peer connection with default configuration.
 	webrtc::PeerConnectionInterface::RTCConfiguration config;

--- a/src/WebRTCLibPeerConnection.hpp
+++ b/src/WebRTCLibPeerConnection.hpp
@@ -18,8 +18,11 @@ class WebRTCLibPeerConnection : public WebRTCPeerConnectionNative {
 private:
 	godot_error _create_pc(webrtc::PeerConnectionInterface::RTCConfiguration &config);
 
+	static std::unique_ptr<rtc::Thread> signaling_thread;
 public:
 	static void _register_methods();
+	static void initialize_signaling();
+	static void deinitialize_signaling();
 
 	void _init();
 
@@ -83,10 +86,9 @@ public:
 	rtc::scoped_refptr<GodotSSDO> ptr_ssdo;
 	rtc::scoped_refptr<GodotCSDO> ptr_csdo;
 
-	std::mutex *mutex_signal_queue;
+	std::mutex *mutex_signal_queue = nullptr;
 	std::queue<std::function<void()> > signal_queue;
 
-	std::unique_ptr<rtc::Thread> signaling_thread;
 	rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> pc_factory;
 	rtc::scoped_refptr<webrtc::PeerConnectionInterface> peer_connection;
 };

--- a/src/WebRTCLibPeerConnection.hpp
+++ b/src/WebRTCLibPeerConnection.hpp
@@ -3,8 +3,8 @@
 
 #include <Godot.hpp> // Godot.hpp must go first, or windows builds breaks
 
-#include "api/peerconnectioninterface.h" // interface for all things needed from WebRTC
-#include "media/base/mediaengine.h" // needed for CreateModularPeerConnectionFactory
+#include "api/peer_connection_interface.h" // interface for all things needed from WebRTC
+#include "media/base/media_engine.h" // needed for CreateModularPeerConnectionFactory
 #include <functional> // std::function
 #include <mutex> // mutex @TODO replace std::mutex with Godot mutex
 
@@ -66,7 +66,7 @@ public:
 
 		GodotCSDO(WebRTCLibPeerConnection *parent);
 		void OnSuccess(webrtc::SessionDescriptionInterface *desc) override;
-		void OnFailure(const std::string &error) override;
+		void OnFailure(webrtc::RTCError error) override;
 	};
 
 	/** SetSessionDescriptionObserver callback functions **/
@@ -76,7 +76,7 @@ public:
 
 		GodotSSDO(WebRTCLibPeerConnection *parent);
 		void OnSuccess() override;
-		void OnFailure(const std::string &error) override;
+		void OnFailure(webrtc::RTCError error) override;
 	};
 
 	GodotPCO pco;
@@ -86,7 +86,7 @@ public:
 	std::mutex *mutex_signal_queue;
 	std::queue<std::function<void()> > signal_queue;
 
-	rtc::Thread *signaling_thread;
+	std::unique_ptr<rtc::Thread> signaling_thread;
 	rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> pc_factory;
 	rtc::scoped_refptr<webrtc::PeerConnectionInterface> peer_connection;
 };

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -86,6 +86,7 @@ extern "C" void GDN_EXPORT godot_gdnative_init(godot_gdnative_init_options *o) {
 		}
 	}
 
+	godot_webrtc::WebRTCLibPeerConnection::initialize_signaling();
 	godot::Godot::gdnative_init(o);
 }
 
@@ -93,6 +94,7 @@ extern "C" void GDN_EXPORT godot_gdnative_terminate(godot_gdnative_terminate_opt
 	if (_singleton) { // If we are the active singleton, unregister
 		WebRTCPeerConnectionNative::_net_api->godot_net_set_webrtc_library(NULL);
 	}
+	godot_webrtc::WebRTCLibPeerConnection::deinitialize_signaling();
 	godot::Godot::gdnative_terminate(o);
 }
 


### PR DESCRIPTION
WebRTC [`branch-heads/4472`](https://webrtc.googlesource.com/src/+/refs/branch-heads/4472) ([chromium M91](https://chromiumdash.appspot.com/branches)). (commit `92ba70c1c575a82b64ae9c99912c0d2955ee3f15`)

[See here](https://github.com/Faless/webrtc-builds/releases/tag/4472-33644-92ba70c) for pre-compiled static webrtc libraries for all supported platforms, along with instructions on how they were built.

This PR also add a single signalling thread, instead of spawning multiple ones like before.
Hopefully fixing some of the undue crashes.