### PR TITLE
Add OSX arm64 build.

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -82,6 +82,10 @@ jobs:
             arch: 'x64'
             sconsflags: 'bits=64'
             os: 'macos-latest'
+          - platform: osx
+            arch: 'arm64'
+            sconsflags: 'bits=64 macos_arch=arm64 macos_sdk_path=/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk/'
+            os: 'macos-10.15'
 
           # Windows
           - platform: windows
@@ -154,6 +158,17 @@ jobs:
         with:
           platform: ${{ matrix.platform }}
           archs: ${{ matrix.arch }}
+
+      - name: Fix godot-cpp revision and file names for OSX arm64 build.
+        if: ${{ matrix.platform == 'osx' && matrix.arch == 'arm64' }}
+        run: |
+          cd godot-cpp
+          git checkout e08ecdc28c5409cb5366027227e996c342dcee93
+          rm -rf src/gen/
+          rm -rf include/gen/
+          mkdir bin
+          ln -s libgodot-cpp.osx.debug.64.a bin/libgodot-cpp.osx.debug.arm64.a
+          ln -s libgodot-cpp.osx.release.64.a bin/libgodot-cpp.osx.release.arm64.a
 
       - name: Compilation ${{ matrix.platform }} - ${{ matrix.arch }} - godot-cpp
         run: |

--- a/SConstruct
+++ b/SConstruct
@@ -70,6 +70,8 @@ opts.Add(
     "Path to iPhone toolchain",
     "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain",
 )
+opts.Add("macos_sdk_path", "macOS SDK path", "")
+opts.Add(EnumVariable("macos_arch", "Target macOS architecture", "x86_64", ["x86_64", "arm64"]))
 
 # Update environment (parse options)
 opts.Update(env)
@@ -149,9 +151,15 @@ elif target_platform == "osx":
 
     # Only 64-bits is supported for OS X
     target_arch = "64"
+    if env["macos_arch"] != "x86_64":
+        target_arch = "arm64"
 
-    env.Append(CCFLAGS=["-std=c++14", "-arch", "x86_64"])
-    env.Append(LINKFLAGS=["-arch", "x86_64", "-framework", "Cocoa", "-Wl,-undefined,dynamic_lookup"])
+    env.Append(CCFLAGS=["-std=c++14", "-arch", env["macos_arch"]])
+    env.Append(LINKFLAGS=["-arch", env["macos_arch"], "-framework", "Cocoa", "-Wl,-undefined,dynamic_lookup"])
+
+    if env["macos_sdk_path"]:
+        env.Append(CCFLAGS=["-isysroot", env["macos_sdk_path"]])
+        env.Append(LINKFLAGS=["-isysroot", env["macos_sdk_path"]])
 
     if env["target"] == "debug":
         env.Append(CCFLAGS=["-Og", "-g"])


### PR DESCRIPTION
Needs a more recent revision of `godot-cpp`, but can still use `godot-headers` from 3.2 . See CI script update for details.