### PR TITLE
Add get_buffered_amount() to WebRTCDataChannel (GDNative)

### DIFF
--- a/src/WebRTCLibDataChannel.cpp
+++ b/src/WebRTCLibDataChannel.cpp
@@ -144,6 +144,11 @@ bool WebRTCLibDataChannel::is_negotiated() const {
 	return channel->negotiated();
 }
 
+int WebRTCLibDataChannel::get_buffered_amount() const {
+	ERR_FAIL_COND_V(channel.get() == nullptr, 0);
+	return channel->buffered_amount();
+}
+
 godot_error WebRTCLibDataChannel::poll() {
 	return GODOT_OK;
 }

--- a/src/WebRTCLibDataChannel.hpp
+++ b/src/WebRTCLibDataChannel.hpp
@@ -87,6 +87,7 @@ public:
 	int get_max_retransmits() const;
 	const char *get_protocol() const;
 	bool is_negotiated() const;
+	int get_buffered_amount() const;
 
 	godot_error poll();
 	void close();

--- a/src/net/WebRTCDataChannelNative.cpp
+++ b/src/net/WebRTCDataChannelNative.cpp
@@ -113,6 +113,10 @@ bool is_negotiated_wdc(const void *user) {
 	return ((WebRTCDataChannelNative *)user)->is_negotiated();
 }
 
+int get_buffered_amount_wdc(const void *user) {
+	return ((WebRTCDataChannelNative *)user)->get_buffered_amount();
+}
+
 godot_error poll_wdc(void *user) {
 	return ((WebRTCDataChannelNative *)user)->poll();
 }

--- a/src/net/WebRTCDataChannelNative.hpp
+++ b/src/net/WebRTCDataChannelNative.hpp
@@ -54,13 +54,30 @@ int get_max_packet_life_time_wdc(const void *);
 int get_max_retransmits_wdc(const void *);
 const char *get_protocol_wdc(const void *);
 bool is_negotiated_wdc(const void *);
+int get_buffered_amount_wdc(const void *);
 godot_error poll_wdc(void *);
 void close_wdc(void *);
+
+#if GODOT_NET_WEBRTC_API_MAJOR == 3 && GODOT_NET_WEBRTC_API_MINOR < 4
+extern "C" {
+/* Extensions to WebRTCDataChannel */
+typedef struct {
+	int (*get_buffered_amount)(const void *);
+
+	void *next; /* For extension? */
+} godot_net_webrtc_data_channel_ext;
+}
+#endif
 
 class WebRTCDataChannelNative : public godot::WebRTCDataChannelGDNative {
 	GODOT_CLASS(WebRTCDataChannelNative, godot::WebRTCDataChannelGDNative);
 
 protected:
+	godot_net_webrtc_data_channel_ext interface_ext = {
+		&get_buffered_amount_wdc,
+		NULL,
+	};
+
 	godot_net_webrtc_data_channel interface = {
 		{ 3, 1 },
 		this,
@@ -84,7 +101,7 @@ protected:
 
 		&poll_wdc,
 		&close_wdc,
-		NULL,
+		&interface_ext,
 	};
 
 public:
@@ -105,6 +122,7 @@ public:
 	virtual int get_max_retransmits() const = 0;
 	virtual const char *get_protocol() const = 0;
 	virtual bool is_negotiated() const = 0;
+	virtual int get_buffered_amount() const = 0;
 
 	virtual godot_error poll() = 0;
 	virtual void close() = 0;


### PR DESCRIPTION
This is a companion to these PRs:

- Godot 4.x: https://github.com/godotengine/godot/pull/50658
- Godot 3.x: https://github.com/godotengine/godot/pull/50659

This requires a minor change to godot-headers in order to compile:

```
diff --git a/net/godot_webrtc.h b/net/godot_webrtc.h
index 15e2df8..d5260cc 100644
--- a/net/godot_webrtc.h
+++ b/net/godot_webrtc.h
@@ -108,6 +108,13 @@ typedef struct {
        void *next; /* For extension? */
 } godot_net_webrtc_data_channel;
 
+/* Extensions to WebRTCDataChannel */
+typedef struct {
+       int (*get_buffered_amount)(const void *);
+
+       void *next; /* For extension? */
+} godot_net_webrtc_data_channel_ext;
+
 /* Set the default GDNative library */
 godot_error GDAPI godot_net_set_webrtc_library(const godot_net_webrtc_library *);
 /* Binds a WebRTCPeerConnectionGDNative to the provided interface */
```

~~As explained on the Godot 4.x PR, this has some backwards compatibility challenges. The `godot_net_webrtc_data_channel` struct changes, which will cause old version of the GDNative plugin to not work until updated, and also updated versions of the GDNative plugin won't work with older versions of Godot. So, I'm not sure how to handle that...~~

UPDATE: Backcompat is now handled per suggestion from @Faless!
