### PR TITLE
[Windows] Fix windows build with mingw.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -67,6 +67,10 @@ else:
     })
     env = env.Clone()
 
+# Patch mingw SHLIBSUFFIX.
+if env["platform"] == "windows" and env["use_mingw"]:
+    env["SHLIBSUFFIX"] = ".dll"
+
 opts.Update(env)
 
 target = env["target"]

--- a/src/init_gdextension.cpp
+++ b/src/init_gdextension.cpp
@@ -37,6 +37,12 @@
 #include "WebRTCLibDataChannel.hpp"
 #include "WebRTCLibPeerConnection.hpp"
 
+#ifdef _WIN32
+// See upstream godot-cpp GH-771.
+#undef GDN_EXPORT
+#define GDN_EXPORT __declspec(dllexport)
+#endif
+
 using namespace godot;
 using namespace godot_webrtc;
 

--- a/src/init_gdnative.cpp
+++ b/src/init_gdnative.cpp
@@ -34,6 +34,12 @@
 #include <gdnative_api_struct.gen.h>
 #include <net/godot_net.h>
 
+#ifdef _WIN32
+// See upstream godot GH-62173.
+#undef GDN_EXPORT
+#define GDN_EXPORT __declspec(dllexport)
+#endif
+
 /* Singleton */
 static bool _singleton = false;
 static const godot_object *_singleton_lib = NULL;


### PR DESCRIPTION
Forces ".dll" extension for library when building with mingw.

Override GDN_EXPORT which is incorrectly defined in the upstream gdnative headers (3.x, godotengine/godot#62173) and godot-cpp include (4.0, godotengine/godot-cpp#771) when building for windows with mingw.

Fixes #52 