### PR TITLE
Fix default data channel write mode to binary.

### DIFF
--- a/src/WebRTCLibDataChannel.hpp
+++ b/src/WebRTCLibDataChannel.hpp
@@ -61,7 +61,7 @@ private:
 	QueuedPacket current_packet;
 	std::shared_ptr<rtc::DataChannel> channel = nullptr;
 
-	WriteMode write_mode = WRITE_MODE_TEXT;
+	WriteMode write_mode = WRITE_MODE_BINARY;
 	ChannelState channel_state = STATE_CONNECTING;
 	bool negotiated = false;
 


### PR DESCRIPTION
It's the engine expected default, and the least surprising for the users since it allows any data to be sent, while text mode requires valid UTF.

See #55