### PR TITLE
Update to work with Godot 4.1

### DIFF
--- a/misc/webrtc.gdextension
+++ b/misc/webrtc.gdextension
@@ -1,6 +1,7 @@
 [configuration]
 
 entry_symbol = "webrtc_extension_init"
+compatibility_minimum = 4.1
 
 [libraries]
 

--- a/src/WebRTCLibPeerConnection.cpp
+++ b/src/WebRTCLibPeerConnection.cpp
@@ -180,7 +180,7 @@ Error WebRTCLibPeerConnection::_initialize(const Dictionary &p_config) {
 	return _create_pc(config);
 }
 
-Object *WebRTCLibPeerConnection::_create_data_channel(const String &p_channel, const Dictionary &p_channel_config) try {
+Ref<WebRTCDataChannel> WebRTCLibPeerConnection::_create_data_channel(const String &p_channel, const Dictionary &p_channel_config) try {
 	ERR_FAIL_COND_V(!peer_connection, nullptr);
 
 	// Read config from dictionary

--- a/src/WebRTCLibPeerConnection.hpp
+++ b/src/WebRTCLibPeerConnection.hpp
@@ -79,7 +79,7 @@ public:
 	SignalingState _get_signaling_state() const override;
 
 	godot::Error _initialize(const godot::Dictionary &p_config) override;
-	godot::Object *_create_data_channel(const godot::String &p_channel, const godot::Dictionary &p_channel_config) override;
+	godot::Ref<godot::WebRTCDataChannel> _create_data_channel(const godot::String &p_channel, const godot::Dictionary &p_channel_config) override;
 	godot::Error _create_offer() override;
 	godot::Error _set_remote_description(const godot::String &type, const godot::String &sdp) override;
 	godot::Error _set_local_description(const godot::String &type, const godot::String &sdp) override;

--- a/src/init_gdextension.cpp
+++ b/src/init_gdextension.cpp
@@ -66,8 +66,8 @@ void unregister_webrtc_extension_types(ModuleInitializationLevel p_level) {
 }
 
 extern "C" {
-GDExtensionBool GDE_EXPORT webrtc_extension_init(const GDExtensionInterface *p_interface, const GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization) {
-	GDExtensionBinding::InitObject init_obj(p_interface, p_library, r_initialization);
+GDExtensionBool GDE_EXPORT webrtc_extension_init(const GDExtensionInterfaceGetProcAddress p_get_proc_address, const GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization) {
+	GDExtensionBinding::InitObject init_obj(p_get_proc_address, p_library, r_initialization);
 
 	init_obj.register_initializer(register_webrtc_extension_types);
 	init_obj.register_terminator(unregister_webrtc_extension_types);


### PR DESCRIPTION
This makes the necessary updates to work with Godot 4.1

It depends on Godot PR https://github.com/godotengine/godot/pull/78237 which removes an old workaround in `WebRTCPeerConnection`'s API. Additionally, you'll need to run `godot --dump-extension-api` with that PR and replace the `extension_api.json` in godot-cpp to pick that change.

I tested this with the `webrtc_minimal` and `webrtc_signaling` demos in https://github.com/godotengine/godot-demo-projects - it's working great for me!