### PR TITLE
[SCons] Fix regression causing unnecessary rebuilds.

### DIFF
--- a/tools/rtc.py
+++ b/tools/rtc.py
@@ -27,7 +27,7 @@ def build_library(env):
     rtc_targets = [env.Dir(env["RTC_BUILD"])] + env["RTC_LIBS"]
     rtc_sources = [env.Dir(env["RTC_SOURCE"])]
     rtc_env.Append(CMAKECONFFLAGS=["'-D%s=%s'" % it for it in rtc_cmake_config(env).items()])
-    rtc_env.Append(CMAKEBUILDFLAGS=["-t", "datachannel-static", "-j%s" % env.GetOption("num_jobs")])
+    rtc_env.Append(CMAKEBUILDFLAGS=["-t", "datachannel-static"])
     rtc = rtc_env.CMake(rtc_targets, rtc_sources, CMAKEBUILDTYPE=env["RTC_BUILD_TYPE"])
     rtc_env.Depends(rtc, rtc_env["SSL_LIBS"])
     return rtc


### PR DESCRIPTION
The num_jobs (-j flag) was being tracked as part of the cmake and openssl build actions, thus causing a rebuild when compiling with different concurrently.

This commit strip the -j flag from the signature of the actions so scons won't rebuild openssl/libdatachannel when changing the parallelism option.

Fixes a regression introduced in #102 .