### PR TITLE
Better normalize the GDNative build environment.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -57,6 +57,10 @@ if env["godot_version"] == "3":
     if env["platform"] == "osx":
         env["platform"] = "macos"  # compatibility with old osx name
         ARGUMENTS["platform"] = "macos"
+        env["CC"] = "clang"  # CC is not set in 3.x and can result in it being "gcc".
+
+    if env["platform"] == "ios":
+        env["ios_min_version"] = "11.0"
 
     # Normalize suffix
     if env["platform"] in ["windows", "linux"]:


### PR DESCRIPTION
The "ios_min_version" is missing from godot-cpp-3.x, and the macos CC variable is not explicitely set to "clang".

Since the values are passed to cmake, they used to cause unnecessary rebuilds of libdatchannel when compiling both version 3 and 4.