### PR TITLE
Build Linux binaries using the Godot toolchian.

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -76,12 +76,14 @@ jobs:
           # Linux
           - platform: linux
             arch: 'x86_32'
+            buildroot: 'i686'
             gdnative_flags: 'bits=32'
             sconsflags: ''
             os: 'ubuntu-20.04'
             cache-name: linux-x86_32
           - platform: linux
             arch: 'x86_64'
+            buildroot: 'x86_64'
             gdnative_flags: 'bits=64'
             sconsflags: ''
             os: 'ubuntu-20.04'
@@ -142,10 +144,24 @@ jobs:
           dpkg -l | grep ii | grep mingw
           update-alternatives --get-selections | grep mingw
 
+      - name: Setup Linux buildroot toolchain cache
+        if: ${{ matrix.platform == 'linux' }}
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ matrix.buildroot }}-godot-linux-gnu_sdk-buildroot.tar.bz2
+          key: linux-${{ matrix.buildroot }}-buildroot
+
       - name: Install Linux build dependencies
         if: ${{ matrix.platform == 'linux' }}
         run: |
-          sudo apt-get install build-essential gcc-multilib g++-multilib
+          sudo apt-get install build-essential gcc-multilib g++-multilib wget
+          if [ ! -f ${{ matrix.buildroot }}-godot-linux-gnu_sdk-buildroot.tar.bz2 ]; then
+            wget https://downloads.tuxfamily.org/godotengine/toolchains/linux/${{ matrix.buildroot }}-godot-linux-gnu_sdk-buildroot.tar.bz2
+          fi
+          tar -xjf ${{ matrix.buildroot }}-godot-linux-gnu_sdk-buildroot.tar.bz2
+          echo "$GITHUB_WORKSPACE/${{ matrix.buildroot }}-godot-linux-gnu_sdk-buildroot/bin" >> $GITHUB_PATH
+          patch -p1 < misc/patches/scons_path.diff
 
       - name: Set up Python 3.x
         uses: actions/setup-python@v4

--- a/misc/patches/scons_path.diff
+++ b/misc/patches/scons_path.diff
@@ -1,0 +1,29 @@
+diff --git a/godot-cpp/SConstruct b/godot-cpp/SConstruct
+index 27ee137..32b425e 100644
+--- a/godot-cpp/SConstruct
++++ b/godot-cpp/SConstruct
+@@ -54,6 +54,8 @@ else:
+ # Default tools with no platform defaults to gnu toolchain.
+ # We apply platform specific toolchains via our custom tools.
+ env = Environment(tools=["default"], PLATFORM="")
++# Allows us to use Godot buildroot toolchain
++env.PrependENVPath("PATH", os.getenv("PATH"))
+
+ # Default num_jobs to local cpu count if not user specified.
+ # SCons has a peculiarity where user-specified options won't be overridden
+
+diff --git a/godot-cpp-3.x/SConstruct b/godot-cpp-3.x/SConstruct
+index f653d54..6f40377 100644
+--- a/godot-cpp-3.x/SConstruct
++++ b/godot-cpp-3.x/SConstruct
+@@ -194,6 +194,9 @@ if host_platform == "windows" and env["platform"] != "android":
+
+     opts.Update(env)
+
++# Allows us to use Godot buildroot toolchain
++env.PrependENVPath("PATH", os.getenv("PATH"))
++
+ # Require C++14
+ if host_platform == "windows" and env["platform"] == "windows" and not env["use_mingw"]:
+     # MSVC
+


### PR DESCRIPTION
So we link to very old glibc and support ancient distros.

Fixes #91