### PR TITLE
Add _to_string method to extension classes.

### DIFF
--- a/src/WebRTCLibDataChannel.hpp
+++ b/src/WebRTCLibDataChannel.hpp
@@ -74,6 +74,10 @@ private:
 protected:
 	static void _bind_methods() {}
 
+	godot::String _to_string() const {
+		return "WebRTCLibDataChannel";
+	}
+
 public:
 	static WebRTCLibDataChannel *new_data_channel(std::shared_ptr<rtc::DataChannel> p_channel, bool p_negotiated);
 

--- a/src/WebRTCLibPeerConnection.hpp
+++ b/src/WebRTCLibPeerConnection.hpp
@@ -67,6 +67,10 @@ private:
 protected:
 	static void _bind_methods() {}
 
+	godot::String _to_string() const {
+		return "WebRTCLibPeerConnection";
+	}
+
 public:
 	static void _register_methods() {}
 	static void initialize_signaling();


### PR DESCRIPTION
So printing them in Godot shows the proper class name instead of "Wrapped".