### PR TITLE
[Linux] Only export extension init symbol

### DIFF
--- a/misc/dist/linux/symbols-extension.map
+++ b/misc/dist/linux/symbols-extension.map
@@ -1,0 +1,6 @@
+{
+    global:
+        webrtc_extension_init;
+    local:
+        *;
+};

--- a/misc/dist/linux/symbols-gdnative.map
+++ b/misc/dist/linux/symbols-gdnative.map
@@ -1,0 +1,9 @@
+{
+    global:
+        godot_gdnative_singleton;
+        godot_gdnative_init;
+        godot_gdnative_terminate;
+        godot_nativescript_init;
+    local:
+        *;
+};

--- a/tools/openssl.py
+++ b/tools/openssl.py
@@ -125,6 +125,8 @@ def build_openssl(env, jobs=None):
         env.Prepend(LIBPATH=[env["SSL_BUILD"]])
         if env["platform"] == "windows":
             env.PrependUnique(LIBS=["crypt32", "ws2_32", "advapi32", "user32"])
+        if env["platform"] == "linux":
+            env.PrependUnique(LIBS=["pthread", "dl"])
         env.Prepend(LIBS=env["SSL_LIBS"])
         return [env["SSL_CRYPTO_LIBRARY"], env["SSL_LIBRARY"]]
 
@@ -169,6 +171,8 @@ def build_openssl(env, jobs=None):
     env.Prepend(LIBPATH=[env["SSL_BUILD"]])
     if env["platform"] == "windows":
         env.PrependUnique(LIBS=["crypt32", "ws2_32", "advapi32", "user32"])
+    if env["platform"] == "linux":
+        env.PrependUnique(LIBS=["pthread", "dl"])
     env.Prepend(LIBS=env["SSL_LIBS"])
 
     return ssl

--- a/tools/rtc.py
+++ b/tools/rtc.py
@@ -37,6 +37,8 @@ def build_library(env, ssl):
     # Configure env.
     if env["platform"] == "windows":
         env.PrependUnique(LIBS=["iphlpapi", "bcrypt"])
+    if env["platform"] == "linux":
+        env.PrependUnique(LIBS=["pthread"])
     env.Prepend(LIBS=list(filter(lambda f: str(f).endswith(lib_ext), rtc)))
     env.Append(CPPPATH=["#thirdparty/libdatachannel/include"])
 


### PR DESCRIPTION
Since we link with static libstdc++ we need to tell gcc to only export the necessary symbols.
Using "-fvisibility=hidden" will not work, since libstdc++ explicitly export its symbols.

Fixes #127 .