### PR TITLE
Call rtc::Cleanup when unloading the library

### DIFF
--- a/src/WebRTCLibPeerConnection.cpp
+++ b/src/WebRTCLibPeerConnection.cpp
@@ -48,6 +48,7 @@ void WebRTCLibPeerConnection::initialize_signaling() {
 }
 
 void WebRTCLibPeerConnection::deinitialize_signaling() {
+	rtc::Cleanup();
 }
 
 Error WebRTCLibPeerConnection::_parse_ice_server(rtc::Configuration &r_config, Dictionary p_server) {


### PR DESCRIPTION
Avoid potential crash at exit.