### PR TITLE
[Build] Fix gdextension file after dropping 4.0

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -241,10 +241,6 @@ if env["godot_version"] == "3":
         },
     )
 else:
-    extfile = env.Substfile(
-        os.path.join(result_path, "webrtc.gdextension"),
-        "misc/webrtc.gdextension",
-        SUBST_DICT={"{GODOT_VERSION}": env["godot_version"]},
-    )
+    extfile = env.InstallAs(os.path.join(result_path, "webrtc.gdextension"), "misc/webrtc.gdextension")
 
 Default(extfile)

--- a/misc/webrtc.gdextension
+++ b/misc/webrtc.gdextension
@@ -1,7 +1,7 @@
 [configuration]
 
 entry_symbol = "webrtc_extension_init"
-compatibility_minimum = {GODOT_VERSION}
+compatibility_minimum = 4.1
 
 [libraries]
 


### PR DESCRIPTION
Renaming the godot version to "4" resulted in the GDExtension file incorrectly setting "compatibility_minimum = 4" (instead of "4.1")