### PR TITLE
fix: Building with CMake 4

### DIFF
--- a/tools/rtc.py
+++ b/tools/rtc.py
@@ -4,6 +4,7 @@ def build_library(env, mbedtls):
         "CMAKE_CXX_FLAGS": "-DMBEDTLS_SSL_DTLS_SRTP",
         "USE_NICE": 0,
         "NO_WEBSOCKET": 1,
+        "CMAKE_POLICY_VERSION_MINIMUM": "3.5",  # Tempoarily needed for CMake 4 support.
         "NO_EXAMPLES": 1,
         "NO_TESTS": 1,
         "BUILD_WITH_WARNINGS": "0",  # Disables werror in libsrtp.


### PR DESCRIPTION
CMake 4 removed compatibility with CMake 3.5 and will refuse to build any project with compatibility set to 3.5 unless the `CMAKE_POLICY_VERSION_MINIMUM` flag is set.

Fixes #176