### PR TITLE
Update uses of memnew to handle godot-cpp returning Ref<> instead of raw pointers.

### DIFF
--- a/src/WebRTCLibDataChannel.cpp
+++ b/src/WebRTCLibDataChannel.cpp
@@ -48,7 +48,11 @@ using namespace godot;
 using namespace godot_webrtc;
 
 // DataChannel
+#ifdef GDNATIVE_WEBRTC
 WebRTCLibDataChannel *WebRTCLibDataChannel::new_data_channel(std::shared_ptr<rtc::DataChannel> p_channel, bool p_negotiated) {
+#else
+Ref<WebRTCLibDataChannel> WebRTCLibDataChannel::new_data_channel(std::shared_ptr<rtc::DataChannel> p_channel, bool p_negotiated) {
+#endif
 	// Invalid channel result in NULL return
 	ERR_FAIL_COND_V(!p_channel, nullptr);
 
@@ -62,7 +66,7 @@ WebRTCLibDataChannel *WebRTCLibDataChannel::new_data_channel(std::shared_ptr<rtc
 	native->set_script(script);
 	WebRTCLibDataChannel *out = native->cast_to<WebRTCLibDataChannel>(native);
 #else
-	WebRTCLibDataChannel *out = memnew(WebRTCLibDataChannel);
+	Ref<WebRTCLibDataChannel> out = memnew(WebRTCLibDataChannel);
 #endif
 	// Bind the library data channel to our object.
 	out->bind_channel(p_channel, p_negotiated);

--- a/src/WebRTCLibDataChannel.hpp
+++ b/src/WebRTCLibDataChannel.hpp
@@ -78,7 +78,11 @@ protected:
 	}
 
 public:
+#ifdef GDNATIVE_WEBRTC
 	static WebRTCLibDataChannel *new_data_channel(std::shared_ptr<rtc::DataChannel> p_channel, bool p_negotiated);
+#else
+	static godot::Ref<WebRTCLibDataChannel> new_data_channel(std::shared_ptr<rtc::DataChannel> p_channel, bool p_negotiated);
+#endif
 
 	/* PacketPeer */
 	virtual godot::Error _get_packet(const uint8_t **r_buffer, int32_t *r_len) override;

--- a/src/WebRTCLibPeerConnection.cpp
+++ b/src/WebRTCLibPeerConnection.cpp
@@ -234,8 +234,13 @@ Ref<WebRTCDataChannel> WebRTCLibPeerConnection::_create_data_channel(const Strin
 	std::shared_ptr<rtc::DataChannel> ch = peer_connection->createDataChannel(p_channel.utf8().get_data(), config);
 	ERR_FAIL_COND_V(ch == nullptr, nullptr);
 
+#ifdef GDNATIVE_WEBRTC
 	WebRTCLibDataChannel *wrapper = WebRTCLibDataChannel::new_data_channel(ch, ch->id().has_value());
 	ERR_FAIL_COND_V(wrapper == nullptr, nullptr);
+#else
+	Ref<WebRTCLibDataChannel> wrapper = WebRTCLibDataChannel::new_data_channel(ch, ch->id().has_value());
+	ERR_FAIL_COND_V(wrapper.is_null(), nullptr);
+#endif
 	return wrapper;
 } catch (const std::exception &e) {
 	ERR_PRINT(e.what());


### PR DESCRIPTION
Not updating the godot-cpp submodule right now, but this will avoid compile errors when that does happen.