### PR TITLE
Wait for cleanup during deinitialization

### DIFF
--- a/src/WebRTCLibPeerConnection.cpp
+++ b/src/WebRTCLibPeerConnection.cpp
@@ -69,7 +69,7 @@ void WebRTCLibPeerConnection::initialize_signaling() {
 }
 
 void WebRTCLibPeerConnection::deinitialize_signaling() {
-	rtc::Cleanup();
+	rtc::Cleanup().wait();
 }
 
 Error WebRTCLibPeerConnection::_parse_ice_server(rtc::Configuration &r_config, Dictionary p_server) {


### PR DESCRIPTION
The `rtc::Cleanup` function returns a future instead of blocking, so we have to wait for it before deinitializing the extension.

Fixes #195